### PR TITLE
Fix storyteller voting and allow transfer vote participation

### DIFF
--- a/config/bubbers/storyteller.txt
+++ b/config/bubbers/storyteller.txt
@@ -1,5 +1,5 @@
 ## Default Storyteller. Comment out to enable voting.
-DEFAULT_STORYTELLER /datum/storyteller/extended
+#DEFAULT_STORYTELLER /datum/storyteller/extended
 
 ## Gamemode configurations
 

--- a/modular_zubbers/code/modules/voting/_votes.dm
+++ b/modular_zubbers/code/modules/voting/_votes.dm
@@ -18,7 +18,8 @@
 
 #undef INGAME_TIME_NEEDED
 /datum/vote/transfer_vote
-	allow_ghosts = FALSE
+    /// Allow ghosts so everyone can vote on the transfer shuttle
+    allow_ghosts = TRUE
 	// Has this vote been run before?
 	var/has_ran = FALSE
 	winner_method = VOTE_WINNER_METHOD_SIMPLE


### PR DESCRIPTION
## Summary
- comment out `DEFAULT_STORYTELLER` to re-enable storyteller voting
- let ghosts participate in the transfer vote so anyone can vote for the shuttle

## Testing
- `./tools/build/build.sh` *(fails: DreamMaker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd3fdc6208325ade6b1feabf59a1f