### PR TITLE
Fix stationary projectiles fired by mobs

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1407,14 +1407,14 @@
 	LAZYINITLIST(bullet.impacted)
 	for (var/atom/thing as anything in ignore_targets)
 		bullet.impacted[WEAKREF(thing)] = TRUE
-		bullet.firer = firer || src
-		bullet.fired_from = src
-		bullet.yo = target.y - startloc.y
-		bullet.xo = target.x - startloc.x
-		bullet.original = target
-		bullet.aim_projectile(target, src)
-		bullet.fire()
-		return bullet
+	bullet.firer = firer || src
+	bullet.fired_from = src
+	bullet.yo = target.y - startloc.y
+	bullet.xo = target.x - startloc.x
+	bullet.original = target
+	bullet.aim_projectile(target, src)
+	bullet.fire()
+	return bullet
 
 #undef MOVES_HITSCAN
 #undef MUZZLE_EFFECT_PIXEL_INCREMENT


### PR DESCRIPTION
## Summary
- ensure projectiles are properly initialized even without ignore targets so they move and impact correctly

## Testing
- `bash tools/ci/check_grep.sh` (fails: Errors found)
- `bash tools/ci/check_misc.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e4afbb5288325af45e0294668209a