### PR TITLE
Ping redbot at round end

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -254,6 +254,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 		for(var/channel_tag in CONFIG_GET(str_list/channel_announce_end_game))
 			send2chat(new /datum/tgs_message_content("[GLOB.round_id ? "Round [GLOB.round_id]" : "The round has"] just ended. [CONFIG_GET(string/roundend_ping_role) ? "" : ""]"), channel_tag)
 	send2adminchat("Server", "Round just ended.")
+	SSredbot.round_end_ping()
 
 	/* //SKYRAT EDIT - START (DISCORD Updates)
 	MOVED CHECK INTO TICKER.DM

--- a/code/controllers/subsystem/redbot.dm
+++ b/code/controllers/subsystem/redbot.dm
@@ -3,14 +3,15 @@ SUBSYSTEM_DEF(redbot)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/redbot/Initialize(timeofday)
-	var/comms_key = CONFIG_GET(string/comms_key)
-	var/bot_ip = CONFIG_GET(string/bot_ip)
-	var/round_id = GLOB.round_id
-	if(bot_ip)
-		var/query = "http://[bot_ip]/?serverStart=1&roundID=[round_id]&key=[comms_key]"
-		world.Export(query)
+        return SS_INIT_SUCCESS
 
-	return SS_INIT_SUCCESS
+/datum/controller/subsystem/redbot/proc/round_end_ping()
+        var/comms_key = CONFIG_GET(string/comms_key)
+        var/bot_ip = CONFIG_GET(string/bot_ip)
+        var/round_id = GLOB.round_id
+        if(bot_ip)
+                var/query = "http://[bot_ip]/?roundEnd=1&roundID=[round_id]&key=[comms_key]"
+                world.Export(query)
 
 /datum/controller/subsystem/redbot/proc/send_discord_message(var/channel, var/message, var/priority_type)
 	var/bot_ip = CONFIG_GET(string/bot_ip)


### PR DESCRIPTION
## Summary
- stop redbot from pinging when the round starts
- ping redbot once the round ends and credits roll

## Testing
- `DreamMaker tgstation.dme` *(fails: cannot execute binary file: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688e85d655488325bdb8e83502bd1d7a