### PR TITLE
Improve Cyrillic runechat text

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -27,6 +27,9 @@
 /// Small size. (ie: context subtooltips, spell delays) - Size options: 12pt 24pt.
 #define MAPTEXT_TINY_UNICODE(text) {"<span style='font-family: \"TinyUnicode\"; font-size: 12pt; line-height: 0.75; -dm-text-outline: 1px black'>[##text]</span>"}
 
+/// TinyUnicode scaled to normal runechat size for crisp Cyrillic text
+#define MAPTEXT_TINY_UNICODE_SMALL(text) {"<span style='font-family: \"TinyUnicode\"; font-size: 6pt; line-height: 1.4; -dm-text-outline: 1px black'>[##text]</span>"}
+
 /// Smallest size. (ie: whisper runechat) - Size options: 6pt 12pt 18pt.
 #define MAPTEXT_SPESSFONT(text) {"<span style='font-family: \"Spess Font\"; font-size: 6pt; line-height: 1.4; -dm-text-outline: 1px black'>[##text]</span>"}
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -191,22 +191,30 @@
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
 
 	// Approximate text height
-	var/complete_text = "<span style='color: [tgt_color]'><span class='center [extra_classes.Join(" ")]'>[owner.apply_message_emphasis(text)]</span></span>"
+       var/complete_text = "<span style='color: [tgt_color]'><span class='center [extra_classes.Join(" ")]'>[owner.apply_message_emphasis(text)]</span></span>"
 
-	var/mheight
-	WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH), mheight)
+       var/uses_unicode = FALSE
+       for(var/i in 1 to length_char(text))
+               if(text2ascii(text, i) > 127)
+                       uses_unicode = TRUE
+                       break
+
+       var/wrapped_text = uses_unicode ? MAPTEXT_TINY_UNICODE_SMALL(complete_text) : MAPTEXT(complete_text)
+
+       var/mheight
+       WXH_TO_HEIGHT(owned_by.MeasureText(wrapped_text, null, CHAT_MESSAGE_WIDTH), mheight)
 
 
-	if(!VERB_SHOULD_YIELD)
-		return finish_image_generation(mheight, target, owner, complete_text, lifespan)
+       if(!VERB_SHOULD_YIELD)
+               return finish_image_generation(mheight, target, owner, wrapped_text, lifespan)
 
-	finish_callback = CALLBACK(src, PROC_REF(finish_image_generation), mheight, target, owner, complete_text, lifespan)
+       finish_callback = CALLBACK(src, PROC_REF(finish_image_generation), mheight, target, owner, wrapped_text, lifespan)
 	SSrunechat.message_queue += finish_callback
 	return
 
 ///finishes the image generation after the MeasureText() call in generate_image().
 ///necessary because after that call the proc can resume at the end of the tick and cause overtime.
-/datum/chatmessage/proc/finish_image_generation(mheight, atom/target, mob/owner, complete_text, lifespan)
+/datum/chatmessage/proc/finish_image_generation(mheight, atom/target, mob/owner, maptext_text, lifespan)
 	finish_callback = null
 	var/rough_time = REALTIMEOFDAY
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
@@ -280,7 +288,7 @@
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight * 1.25 // We add extra because some characters are superscript, like actions
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5
-	message.maptext = MAPTEXT(complete_text)
+       message.maptext = maptext_text
 
 	animate_start = rough_time
 	animate_lifespan = lifespan
@@ -345,7 +353,7 @@
 
 	// Display visual above source
 	if(runechat_flags & EMOTE_MESSAGE)
-		new /datum/chatmessage(raw_message, speaker, src, message_language, list("emote", "italics"))
+               new /datum/chatmessage(raw_message, speaker, src, message_language, list("italics"))
 	else
 		new /datum/chatmessage(raw_message, speaker, src, message_language, spans)
 

--- a/html/changelogs/AutoChangeLog-russian-runechat.yml
+++ b/html/changelogs/AutoChangeLog-russian-runechat.yml
@@ -1,0 +1,4 @@
+author: "OpenAI"
+delete-after: True
+changes:
+  - qol: "Runechat now renders Cyrillic text with a crisp pixel-perfect font"


### PR DESCRIPTION
## Summary
- Render Cyrillic runechat messages with a pixel-perfect TinyUnicode font
- /me emotes now use the same readable size as other runechat messages
- Document improved Cyrillic clarity in the changelog

## Testing
- `bash tools/ci/check_misc.sh`
- `bash tools/ci/check_changelogs.sh`
- `DreamMaker tgstation.dme` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5e73a1088325bc9a4eebac27750d