### PR TITLE
Increase wait times for heavy subsystems

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(lighting)
 		/datum/controller/subsystem/atoms,
 		/datum/controller/subsystem/mapping,
 	)
-	wait = 2
+	wait = 3
 	flags = SS_TICKER
 	var/static/list/sources_queue = list() // List of lighting sources queued for update.
 	var/static/list/corners_queue = list() // List of lighting corners queued for update.

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(machines)
 		/datum/controller/subsystem/atoms,
 	)
 	flags = SS_KEEP_TIMING
-	wait = 2 SECONDS
+	wait = 3 SECONDS
 
 	/// Assosciative list of all machines that exist.
 	VAR_PRIVATE/list/machines_by_type = list()

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(mobs)
 	priority = FIRE_PRIORITY_MOBS
 	flags = SS_KEEP_TIMING | SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
-	wait = 2 SECONDS
+        wait = 3 SECONDS
 
 	var/list/currentrun = list()
 	///only contains living players for some reason


### PR DESCRIPTION
## Summary
- Run lighting subsystem less frequently
- Slow down machine subsystem to lighten server load
- Slow mob subsystem to reduce Life() overhead

## Testing
- `bash tools/ci/check_grep.sh` (fails: existing style issues)
- `bash tools/ci/check_misc.sh`


------
https://chatgpt.com/codex/tasks/task_e_688fc34722e48325ad680d77519e90f9