### PR TITLE
Hide descriptions when face is obscured

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -321,9 +321,8 @@
 	var/flavor_text_link
 	/// The first 1-FLAVOR_PREVIEW_LIMIT characters in the mob's "flavor_text" DNA feature. FLAVOR_PREVIEW_LIMIT is defined in flavor_defines.dm.
 	var/preview_text = copytext_char((dna.features["flavor_text"]), 1, FLAVOR_PREVIEW_LIMIT)
-	// What examine_tgui.dm uses to determine if flavor text appears as "Obscured".
-	var/obscurity_examine_pref = (client?.prefs?.read_preference(/datum/preference/toggle/obscurity_examine)) //BUBBERSTATION EDIT
-	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE) && obscurity_examine_pref) || (head && (head.flags_inv & HIDEFACE) && obscurity_examine_pref) // BUBBERSTATION EDIT
+        // What examine_tgui.dm uses to determine if flavor text appears as "Obscured".
+        var/face_obscured = !is_face_visible()
 
 	if (!(face_obscured))
 		flavor_text_link = span_notice("[preview_text]... <a href='byond://?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")
@@ -341,12 +340,12 @@
 			. += "<a href='byond://?src=[REF(src)];exprecords=1'>\[View exploitable info\]</a>"
 	//BUBBER EDIT END
 
-	//Temporary flavor text addition:
-	if(temporary_flavor_text)
-		if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
-			. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
-		else
-			. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
+        //Temporary flavor text addition:
+        if(temporary_flavor_text && !face_obscured)
+                if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
+                        . += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
+                else
+                        . += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
 
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)

--- a/html/changelogs/Codex-mask-description.yml
+++ b/html/changelogs/Codex-mask-description.yml
@@ -1,0 +1,4 @@
+author: "Codex"
+delete-after: True
+changes:
+  - bugfix: "Face-covering clothing now hides character descriptions and temporary flavor text."

--- a/modular_zubbers/code/modules/client/verbs/character_directory.dm
+++ b/modular_zubbers/code/modules/client/verbs/character_directory.dm
@@ -209,7 +209,7 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 		if(ishuman(mob))
 			var/mob/living/carbon/human/human = mob
 			//If someone is obscured without flavor text visible, we don't want them on the Directory.
-			if((human.wear_mask && (human.wear_mask.flags_inv & HIDEFACE) && READ_PREFS(human, toggle/obscurity_examine)) || (human.head && (human.head.flags_inv & HIDEFACE) && READ_PREFS(human, toggle/obscurity_examine)) || (HAS_TRAIT(human, TRAIT_UNKNOWN)))
+			if((human.wear_mask && (human.wear_mask.flags_inv & HIDEFACE)) || (human.head && (human.head.flags_inv & HIDEFACE)) || (HAS_TRAIT(human, TRAIT_UNKNOWN)))
 				continue
 			//Display custom species, otherwise show base species instead
 			species = (READ_PREFS(human, text/custom_species))

--- a/modular_zubbers/code/modules/examine_tgui/examine_tgui.dm
+++ b/modular_zubbers/code/modules/examine_tgui/examine_tgui.dm
@@ -66,7 +66,6 @@
 	var/custom_species_lore
 	var/obscured
 	var/name = ""
-	var/obscurity_examine_pref = preferences?.read_preference(/datum/preference/toggle/obscurity_examine)
 	var/ooc_notes = ""
 	var/headshot = ""
 	var/headshot_nsfw = ""
@@ -136,11 +135,9 @@
 			ooc_notes += "Round Removal Opt-In Status: [rr_prefs ? "Yes" : "No"]\n"
 			ooc_notes += "\n"
 
-	if(ishuman(holder))
-		var/mob/living/carbon/human/holder_human = holder
-		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) && \
-		obscurity_examine_pref || \
-		(holder_human.head && (holder_human.head.flags_inv & HIDEFACE) && obscurity_examine_pref)
+        if(ishuman(holder))
+                var/mob/living/carbon/human/holder_human = holder
+                obscured = !holder_human.is_face_visible()
 
 		//Check if the mob is obscured, then continue to headshot and species lore
 		ooc_notes += holder_human.dna?.features["ooc_notes"]


### PR DESCRIPTION
## Summary
- ensure face-covering items like bandanas hide a character's description
- clean up directory listing for obscured characters
- skip temporary flavor text when faces are hidden

## Testing
- `bash tools/ci/check_changelogs.sh`
- `bash tools/ci/check_misc.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890b47969208325806aa994f25e1b7b