### PR TITLE
Cache verb type lists across rounds

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -169,6 +169,7 @@ GLOBAL_VAR(restart_counter)
 
 	load_poll_data()
 
+	LoadVerbCache()
 	LoadVerbs(/datum/verbs/menu)
 
 	if(fexists(RESTART_COUNTER_PATH))
@@ -379,6 +380,7 @@ GLOBAL_VAR(restart_counter)
 				return FALSE
 
 /world/Reboot(reason = 0, fast_track = FALSE)
+	SaveVerbCache()
 	if (reason || fast_track) //special reboot, do none of the normal stuff
 		if (usr)
 			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")


### PR DESCRIPTION
## Summary
- cache verb type sublists to avoid `subtypesof()` on every world start
- persist cached verb lists to `data/verbs_cache.json`

## Testing
- `dreamchecker` *(failed: exited during analyzing proc call tree)*
- `bash tools/ci/check_misc.sh`


------
https://chatgpt.com/codex/tasks/task_e_6891afc99a308325868f1890b0cb4ea7