### PR TITLE
Add admins subsystem with cached loading

### DIFF
--- a/code/controllers/subsystem/admins.dm
+++ b/code/controllers/subsystem/admins.dm
@@ -1,0 +1,12 @@
+SUBSYSTEM_DEF(admins)
+	name = "Admins"
+	flags = SS_NO_FIRE
+	init_stage = INITSTAGE_EARLY
+
+/datum/controller/subsystem/admins/Initialize()
+	load_admins_from_json()
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(load_admins), FALSE, TRUE)
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/admins/Start()
+	return SS_INIT_SUCCESS

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -33,7 +33,6 @@ GLOBAL_VAR(restart_counter)
  *   - world.ConfigLoaded() =>
  *     - SSdbcore.InitializeRound()
  *     - world.SetupLogs()
- *     - load_admins()
  *     - ...
  *   - Master.Initialize() =>
  *     - (all subsystems) Initialize()
@@ -156,18 +155,15 @@ GLOBAL_VAR(restart_counter)
 
 /// Runs after config is loaded but before Master is initialized
 /world/proc/ConfigLoaded()
-	// Everything in here is prioritized in a very specific way.
-	// If you need to add to it, ask yourself hard if what your adding is in the right spot
-	// (i.e. basically nothing should be added before load_admins() in here)
+        // Everything in here is prioritized in a very specific way.
+        // If you need to add to it, ask yourself hard if what you're adding is in the right spot
 
 	// Try to set round ID
 	SSdbcore.InitializeRound()
 
 	SetupLogs()
 
-	load_admins(initial = TRUE)
-
-	load_poll_data()
+        load_poll_data()
 
 	LoadVerbs(/datum/verbs/menu)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -820,6 +820,7 @@
 #include "code\controllers\subsystem\achievements.dm"
 #include "code\controllers\subsystem\addiction.dm"
 #include "code\controllers\subsystem\admin_verbs.dm"
+#include "code\controllers\subsystem\admins.dm"
 #include "code\controllers\subsystem\ai_controllers.dm"
 #include "code\controllers\subsystem\ai_idle_controllers.dm"
 #include "code\controllers\subsystem\air.dm"


### PR DESCRIPTION
## Summary
- Add `SSadmins` subsystem that loads cached admins and refreshes asynchronously
- Remove world `load_admins` call in favor of subsystem
- Support reading cached admin data from JSON before DB sync

## Testing
- `DreamMaker tgstation.dme` *(fails: cannot execute binary file: Exec format error)*
- `bash tools/ci/check_changelogs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6891afa60d3083258d1cde137e09ce4c