### PR TITLE
refactor: lazily initialize global datum lists

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -10,15 +10,43 @@
 	sort_list(surgeries, GLOBAL_PROC_REF(cmp_typepaths_asc))
 	return surgeries
 
-/// Legacy procs that really should be replaced with proper _INIT macros
-/proc/make_datum_reference_lists()
-	// I tried to eliminate this proc but I couldn't untangle their init-order interdependencies -Dominion/Cyberboss
-	init_keybindings()
-	make_skyrat_datum_references() //SKYRAT EDIT ADDITION - CUSTOMIZATION
-	GLOB.emote_list = init_emote_list() // WHY DOES THIS NEED TO GO HERE? IT JUST INITS DATUMS
-	init_skyrat_stack_recipes() //SKYRAT EDIT ADDITION - More sheet recipes
-	init_crafting_recipes()
-	init_crafting_recipes_atoms()
+/// Initializes keybinding datums on first use
+/proc/ensure_keybinding_lists()
+       if(length(GLOB.keybindings_by_name))
+               return
+       init_keybindings()
+
+/// Initializes customization related datums on first use
+/proc/ensure_customization_lists()
+       if(length(GLOB.scream_types))
+               return
+       make_skyrat_datum_references() //SKYRAT EDIT ADDITION - CUSTOMIZATION
+
+/// Initializes emote datums on first use
+/proc/ensure_emote_list()
+       if(length(GLOB.emote_list))
+               return
+       GLOB.emote_list = init_emote_list() // WHY DOES THIS NEED TO GO HERE? IT JUST INITS DATUMS
+
+/// Initializes crafting recipes on first use
+/proc/ensure_crafting_recipes()
+       if(length(GLOB.crafting_recipes) || length(GLOB.cooking_recipes))
+               return
+       init_skyrat_stack_recipes() //SKYRAT EDIT ADDITION - More sheet recipes
+       init_crafting_recipes()
+       init_crafting_recipes_atoms()
+
+/// Initializes surgeries list on first use
+/proc/ensure_surgeries_list()
+       if(length(GLOB.surgeries_list))
+               return
+       GLOB.surgeries_list = init_surgeries()
+
+/// Initializes surgery steps on first use
+/proc/ensure_surgery_steps()
+       if(length(GLOB.surgery_steps))
+               return
+       GLOB.surgery_steps = init_subtypes_w_path_keys(/datum/surgery_step, list())
 
 /// Inits crafting recipe lists
 /proc/init_crafting_recipes(list/crafting_recipes)

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -34,10 +34,10 @@ GLOBAL_LIST_EMPTY_TYPED(singularities, /datum/component/singularity)
 GLOBAL_LIST_EMPTY(item_to_design_list)
 
 /// list of all surgeries by name, associated with their path.
-GLOBAL_LIST_INIT(surgeries_list, init_surgeries())
+GLOBAL_LIST_EMPTY(surgeries_list)
 
 /// list of all surgery steps, associated by their path.
-GLOBAL_LIST_INIT(surgery_steps, init_subtypes_w_path_keys(/datum/surgery_step, list()))
+GLOBAL_LIST_EMPTY(surgery_steps)
 
 /// Global list of all non-cooking related crafting recipes.
 GLOBAL_LIST_EMPTY(crafting_recipes)

--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -65,6 +65,4 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 		if(end_tick - start_tick)
 			warning("Global [replacetext("[I]", "InitGlobal", "")] slept during initialization!")
 
-	// Someone make it so this call isn't necessary
-	make_datum_reference_lists()
 

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -449,7 +449,8 @@
 		ui.open()
 
 /datum/component/personal_crafting/ui_data(mob/user)
-	var/list/data = list()
+       ensure_crafting_recipes()
+       var/list/data = list()
 	data["busy"] = busy
 	data["mode"] = mode
 	data["display_craftable_only"] = display_craftable_only
@@ -467,7 +468,8 @@
 	return data
 
 /datum/component/personal_crafting/ui_static_data(mob/user)
-	var/list/data = list()
+       ensure_crafting_recipes()
+       var/list/data = list()
 	var/list/material_occurences = list()
 
 	data["forced_mode"] = forced_mode
@@ -545,7 +547,8 @@
 
 
 /datum/component/personal_crafting/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
+       ensure_crafting_recipes()
+       . = ..()
 	if(.)
 		return
 	switch(action)
@@ -584,8 +587,9 @@
 	)
 
 /datum/component/personal_crafting/proc/build_crafting_data(datum/crafting_recipe/recipe)
-	var/list/data = list()
-	var/list/atoms = mode ? GLOB.cooking_recipes_atoms : GLOB.crafting_recipes_atoms
+       ensure_crafting_recipes()
+       var/list/data = list()
+       var/list/atoms = mode ? GLOB.cooking_recipes_atoms : GLOB.crafting_recipes_atoms
 
 	data["ref"] = "[REF(recipe)]"
 	var/atom/atom = recipe.result

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -81,7 +81,8 @@
 	ui_interact(user)
 
 /datum/component/surgery_initiator/proc/get_available_surgeries(mob/user, mob/living/target)
-	var/list/available_surgeries = list()
+       ensure_surgeries_list()
+       var/list/available_surgeries = list()
 
 	var/obj/item/bodypart/affecting = target.get_bodypart(check_zone(user.zone_selected))
 

--- a/code/datums/elements/slapcrafting.dm
+++ b/code/datums/elements/slapcrafting.dm
@@ -69,8 +69,9 @@
 	INVOKE_ASYNC(src, PROC_REF(slapcraft_async), parent_item, valid_recipes, user, craft_sheet)
 
 /datum/element/slapcrafting/proc/slapcraft_async(obj/parent_item, list/valid_recipes, mob/user, datum/component/personal_crafting/craft_sheet)
+       ensure_crafting_recipes()
 
-	var/list/recipe_choices = list()
+       var/list/recipe_choices = list()
 
 	var/list/result_to_recipe = list()
 

--- a/code/datums/hotkeys_help.dm
+++ b/code/datums/hotkeys_help.dm
@@ -12,8 +12,9 @@
 
 // Not static data since user could rebind keys.
 /datum/hotkeys_help/ui_data(mob/user)
-	// List every keybind to chat.
-	var/list/keys_list = list()
+       ensure_keybinding_lists()
+       // List every keybind to chat.
+       var/list/keys_list = list()
 
 	// Show them in alphabetical order by key
 	var/list/key_bindings_by_key = user.client.prefs.key_bindings_by_key.Copy()

--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -130,8 +130,9 @@
 	data["patient"]["fireLoss"] = patient.getFireLoss()
 	data["patient"]["toxLoss"] = patient.getToxLoss()
 	data["patient"]["oxyLoss"] = patient.getOxyLoss()
-	if(patient.surgeries.len)
-		for(var/datum/surgery/procedure in patient.surgeries)
+       if(patient.surgeries.len)
+               ensure_surgery_steps()
+               for(var/datum/surgery/procedure in patient.surgeries)
 			var/datum/surgery_step/surgery_step = GLOB.surgery_steps[procedure.steps[procedure.status]]
 			var/chems_needed = surgery_step.get_chem_list()
 			var/alternative_step

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -85,7 +85,8 @@
 			return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/door/poddoor/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(deconstruction == BLASTDOOR_NEEDS_WIRES && istype(tool, /obj/item/stack/cable_coil))
+       ensure_crafting_recipes()
+       if(deconstruction == BLASTDOOR_NEEDS_WIRES && istype(tool, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/coil = tool
 		var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
 		var/amount_needed = recipe.reqs[/obj/item/stack/cable_coil]
@@ -171,7 +172,8 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/door/poddoor/wirecutter_act(mob/living/user, obj/item/tool)
-	. = ..()
+       ensure_crafting_recipes()
+       . = ..()
 	if (density)
 		balloon_alert(user, "open the door first!")
 		return ITEM_INTERACT_SUCCESS
@@ -190,7 +192,8 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/door/poddoor/welder_act(mob/living/user, obj/item/tool)
-	. = ..()
+       ensure_crafting_recipes()
+       . = ..()
 	if (density)
 		balloon_alert(user, "open the door first!")
 		return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/items/granters/crafting/_crafting_granter.dm
+++ b/code/game/objects/items/granters/crafting/_crafting_granter.dm
@@ -3,7 +3,8 @@
 	var/list/crafting_recipe_types = list()
 
 /obj/item/book/granter/crafting_recipe/on_reading_finished(mob/user)
-	. = ..()
+       ensure_crafting_recipes()
+       . = ..()
 	if(!user.mind)
 		return
 	for(var/crafting_recipe_type in crafting_recipe_types)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -21,8 +21,7 @@ GLOBAL_VAR(restart_counter)
  *     - Master =>
  *       - config *unloaded
  *       - (all subsystems) PreInit()
- *       - GLOB =>
- *         - make_datum_reference_lists()
+*       - GLOB => (lazy datum reference lists initialize on access)
  *   - (/static variable inits, reverse declaration order)
  * - (all pre-mapped atoms) /atom/New()
  * - world.New() =>

--- a/code/modules/asset_cache/assets/crafting.dm
+++ b/code/modules/asset_cache/assets/crafting.dm
@@ -3,8 +3,9 @@
 	name = "crafting"
 
 /datum/asset/spritesheet_batched/crafting/create_spritesheets()
-	var/id = 1
-	for(var/atom in GLOB.crafting_recipes_atoms)
+       ensure_crafting_recipes()
+       var/id = 1
+       for(var/atom in GLOB.crafting_recipes_atoms)
 		add_atom_icon(atom, id++)
 	add_tool_icons()
 
@@ -12,8 +13,9 @@
 	name = "cooking"
 
 /datum/asset/spritesheet_batched/crafting/cooking/create_spritesheets()
-	var/id = 1
-	for(var/atom in GLOB.cooking_recipes_atoms)
+       ensure_crafting_recipes()
+       var/id = 1
+       for(var/atom in GLOB.cooking_recipes_atoms)
 		add_atom_icon(atom, id++)
 
 /**

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -115,10 +115,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		refresh_membership()
 	else
 		CRASH("attempted to create a preferences datum without a client or mock!")
-	load_savefile()
+       load_savefile()
+       ensure_keybinding_lists()
+       ensure_customization_lists()
 
-	// give them default keybinds and update their movement keys
-	key_bindings = deep_copy_list(GLOB.default_hotkeys)
+       // give them default keybinds and update their movement keys
+       key_bindings = deep_copy_list(GLOB.default_hotkeys)
 	key_bindings_by_key = get_key_bindings_by_key(key_bindings)
 	randomise = get_default_randomization()
 

--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -24,7 +24,8 @@
 	)
 
 /datum/preference_middleware/keybindings/proc/reset_all_keybinds(list/params, mob/user)
-	preferences.key_bindings = deep_copy_list(GLOB.default_hotkeys)
+       ensure_keybinding_lists()
+       preferences.key_bindings = deep_copy_list(GLOB.default_hotkeys)
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 	preferences.update_static_data(user)
 	user.client.update_special_keybinds()
@@ -32,8 +33,9 @@
 	return TRUE
 
 /datum/preference_middleware/keybindings/proc/reset_keybinds_to_defaults(list/params, mob/user)
-	var/keybind_name = params["keybind_name"]
-	var/datum/keybinding/keybinding = GLOB.keybindings_by_name[keybind_name]
+       ensure_keybinding_lists()
+       var/keybind_name = params["keybind_name"]
+       var/datum/keybinding/keybinding = GLOB.keybindings_by_name[keybind_name]
 
 	if (isnull(keybinding))
 		return FALSE
@@ -47,7 +49,8 @@
 	return TRUE
 
 /datum/preference_middleware/keybindings/proc/set_keybindings(list/params, mob/user)
-	var/keybind_name = params["keybind_name"]
+       ensure_keybinding_lists()
+       var/keybind_name = params["keybind_name"]
 
 	if (isnull(GLOB.keybindings_by_name[keybind_name]))
 		return FALSE
@@ -83,7 +86,8 @@
 	name = "keybindings"
 
 /datum/asset/json/keybindings/generate()
-	var/list/keybindings = list()
+       ensure_keybinding_lists()
+       var/list/keybindings = list()
 
 	for (var/name in GLOB.keybindings_by_name)
 		var/datum/keybinding/keybinding = GLOB.keybindings_by_name[name]

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -141,8 +141,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()
-	if(!parent)
-		return
+       ensure_keybinding_lists()
+       if(!parent)
+               return
 	var/list/binds_by_key = get_key_bindings_by_key(key_bindings)
 	var/list/notadded = list()
 	for (var/name in GLOB.keybindings_by_name)
@@ -456,7 +457,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	return output.len == input_be_special.len ? input_be_special : output
 
 /proc/sanitize_keybindings(value)
-	var/list/base_bindings = sanitize_islist(value,list())
+       ensure_keybinding_lists()
+       var/list/base_bindings = sanitize_islist(value,list())
 	for(var/keybind_name in base_bindings)
 		if (!(keybind_name in GLOB.keybindings_by_name))
 			base_bindings -= keybind_name

--- a/code/modules/emote_panel/emote_panel.dm
+++ b/code/modules/emote_panel/emote_panel.dm
@@ -2,7 +2,8 @@
 	var/list/blacklisted_emotes = list("me", "help")
 
 /datum/emote_panel/ui_static_data(mob/user)
-	var/list/data = list()
+       ensure_emote_list()
+       var/list/data = list()
 
 	var/list/emotes = list()
 	var/list/keys = list()
@@ -30,7 +31,8 @@
 	return data
 
 /datum/emote_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
+       ensure_emote_list()
+       . = ..()
 	if(.)
 		return
 	switch(action)

--- a/code/modules/fishing/sources/subtypes/surgery.dm
+++ b/code/modules/fishing/sources/subtypes/surgery.dm
@@ -12,17 +12,18 @@
 	wait_time_range = list(6 SECONDS, 12 SECONDS)
 
 /datum/fish_source/surgery/spawn_reward(reward_path, atom/spawn_location, atom/fishing_spot, obj/item/fishing_rod/used_rod)
-	if(istype(fishing_spot, /obj/machinery/fishing_portal_generator))
-		var/obj/machinery/fishing_portal_generator/portal = fishing_spot
-		fishing_spot = portal.current_linked_atom
-	if(!iscarbon(fishing_spot))
-		var/random_type = pick(subtypesof(/obj/item/organ) - GLOB.prototype_organs)
-		return new random_type(spawn_location)
+       if(istype(fishing_spot, /obj/machinery/fishing_portal_generator))
+               var/obj/machinery/fishing_portal_generator/portal = fishing_spot
+               fishing_spot = portal.current_linked_atom
+       if(!iscarbon(fishing_spot))
+               var/random_type = pick(subtypesof(/obj/item/organ) - GLOB.prototype_organs)
+               return new random_type(spawn_location)
 
-	var/mob/living/carbon/carbon = fishing_spot
-	var/list/possible_organs = list()
-	for(var/datum/surgery/organ_manipulation/operation in carbon.surgeries)
-		var/datum/surgery_step/manipulate_organs/manip_step = GLOB.surgery_steps[operation.steps[operation.status]]
+       var/mob/living/carbon/carbon = fishing_spot
+       var/list/possible_organs = list()
+       ensure_surgery_steps()
+       for(var/datum/surgery/organ_manipulation/operation in carbon.surgeries)
+               var/datum/surgery_step/manipulate_organs/manip_step = GLOB.surgery_steps[operation.steps[operation.status]]
 		if(!istype(manip_step))
 			continue
 		for(var/obj/item/organ/organ in operation.operated_bodypart)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -1,10 +1,11 @@
 // Clients aren't datums so we have to define these procs indpendently.
 // These verbs are called for all key press and release events
 /client/verb/keyDown(_key as text, mousepos_x as num, mousepos_y as num, sizex as num, sizey as num)
-	set instant = TRUE
-	set hidden = TRUE
+       set instant = TRUE
+       set hidden = TRUE
 
-	client_keysend_amount += 1
+       ensure_keybinding_lists()
+       client_keysend_amount += 1
 
 	var/cache = client_keysend_amount
 
@@ -83,10 +84,11 @@
 	mob.update_mouse_pointer()
 
 /client/verb/keyUp(_key as text, mousepos_x as num, mousepos_y as num, sizex as num, sizey as num)
-	set instant = TRUE
-	set hidden = TRUE
+       set instant = TRUE
+       set hidden = TRUE
 
-	var/key_combo = key_combos_held[_key]
+       ensure_keybinding_lists()
+       var/key_combo = key_combos_held[_key]
 	if(key_combo)
 		key_combos_held -= _key
 		keyUp(key_combo, mousepos_x, mousepos_y, sizex, sizey)

--- a/code/modules/manufactorio/machines/crafter.dm
+++ b/code/modules/manufactorio/machines/crafter.dm
@@ -18,10 +18,11 @@
 	var/cooking = FALSE
 
 /obj/machinery/power/manufacturing/crafter/Initialize(mapload)
-	. = ..()
-	craftsman = AddComponent(/datum/component/personal_crafting/machine)
-	if(ispath(recipe))
-		recipe = locate(recipe) in (cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes)
+       . = ..()
+       craftsman = AddComponent(/datum/component/personal_crafting/machine)
+       ensure_crafting_recipes()
+       if(ispath(recipe))
+               recipe = locate(recipe) in (cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes)
 	START_PROCESSING(SSmanufacturing, src)
 
 /obj/machinery/power/manufacturing/crafter/examine(mob/user)
@@ -50,9 +51,10 @@
 	return MANUFACTURING_SUCCESS
 
 /obj/machinery/power/manufacturing/crafter/multitool_act(mob/living/user, obj/item/tool)
-	. = NONE
-	var/list/unavailable = list()
-	for(var/datum/crafting_recipe/potential_recipe as anything in cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes)
+       ensure_crafting_recipes()
+       . = NONE
+       var/list/unavailable = list()
+       for(var/datum/crafting_recipe/potential_recipe as anything in cooking ? GLOB.cooking_recipes : GLOB.crafting_recipes)
 		var/obj/as_obj = potential_recipe.result
 		if(!(ispath(as_obj, /obj) && !ispath(as_obj, /obj/effect) && initial(as_obj.anchored)) && craftsman.is_recipe_available(potential_recipe, user))
 			continue

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -13,14 +13,15 @@
 
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
-	var/param = message
+       var/param = message
 	var/custom_param = findchar(act, " ")
 	if(custom_param)
 		param = copytext(act, custom_param + length(act[custom_param]))
 		act = copytext(act, 1, custom_param)
 
-	act = LOWER_TEXT(act)
-	var/list/key_emotes = GLOB.emote_list[act]
+       act = LOWER_TEXT(act)
+       ensure_emote_list()
+       var/list/key_emotes = GLOB.emote_list[act]
 
 	if(!length(key_emotes))
 		if(intentional && !force_silence)
@@ -49,7 +50,8 @@
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer, /mob/living/silicon/ai, /mob/eye/imaginary_friend)
 
 /datum/emote/help/run_emote(mob/user, params, type_override, intentional)
-	. = ..()
+       ensure_emote_list()
+       . = ..()
 	var/list/keys = list()
 	var/list/message = list("Available emotes, you can use them with say [span_bold("\"*emote\"")]: \n")
 	message += span_smallnoticeital("Note - emotes highlighted in blue play a sound \n\n")

--- a/code/modules/mob/living/basic/pets/pet_designer.dm
+++ b/code/modules/mob/living/basic/pets/pet_designer.dm
@@ -134,7 +134,8 @@ GLOBAL_LIST_INIT(pet_options, list(
 	return pet_options
 
 /datum/pet_customization/ui_act(action, params, datum/tgui/ui)
-	. = ..()
+       ensure_emote_list()
+       . = ..()
 	switch(action)
 		if("finalize_pet")
 

--- a/code/modules/modular_computers/file_system/programs/virtual_pet.dm
+++ b/code/modules/modular_computers/file_system/programs/virtual_pet.dm
@@ -556,11 +556,12 @@ GLOBAL_LIST_EMPTY(virtual_pets_list)
 			else
 				update_message["likers"] += our_reference
 
-		if("teach_tricks")
-			var/trick_name = params["trick_name"]
-			var/list/trick_sequence = params["tricks"]
-			if(isnull(pet.ai_controller))
-				return TRUE
+               if("teach_tricks")
+                       ensure_emote_list()
+                       var/trick_name = params["trick_name"]
+                       var/list/trick_sequence = params["tricks"]
+                       if(isnull(pet.ai_controller))
+                               return TRUE
 			if(!isnull(trick_name))
 				pet.ai_controller.set_blackboard_key(BB_TRICK_NAME, trick_name)
 			for (var/trick_move in trick_sequence)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -110,8 +110,8 @@
 	return .
 
 /datum/surgery/proc/next_step(mob/living/user, modifiers)
-	if(location != user.zone_selected)
-		return FALSE
+       if(location != user.zone_selected)
+               return FALSE
 	if(user.combat_mode)
 		return FALSE
 	if(step_in_progress)
@@ -121,7 +121,8 @@
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		try_to_fail = TRUE
 
-	var/datum/surgery_step/surgery_step = GLOB.surgery_steps[steps[status]]
+       ensure_surgery_steps()
+       var/datum/surgery_step/surgery_step = GLOB.surgery_steps[steps[status]]
 	if(isnull(surgery_step))
 		return FALSE
 	var/obj/item/tool = user.get_active_held_item()

--- a/code/modules/unit_tests/crafting.dm
+++ b/code/modules/unit_tests/crafting.dm
@@ -14,7 +14,8 @@
 /datum/unit_test/crafting
 
 /datum/unit_test/crafting/Run()
-	var/atom/movable/crafter = allocate(__IMPLIED_TYPE__)
+       ensure_crafting_recipes()
+       var/atom/movable/crafter = allocate(__IMPLIED_TYPE__)
 
 	///Clear the area around our crafting movable of objects that may mess with the unit test
 	for(var/atom/movable/trash in (range(1, crafter) - crafter))

--- a/code/modules/unit_tests/slime_mood.dm
+++ b/code/modules/unit_tests/slime_mood.dm
@@ -2,7 +2,8 @@
 /datum/unit_test/slime_mood
 
 /datum/unit_test/slime_mood/Run()
-	var/mob/living/basic/slime/emoting_slime = allocate(/mob/living/basic/slime)
+       ensure_emote_list()
+       var/mob/living/basic/slime/emoting_slime = allocate(/mob/living/basic/slime)
 
 	for(var/key in GLOB.emote_list)
 		for(var/datum/emote/slime/mood/slime_mood in GLOB.emote_list[key])

--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -7,9 +7,10 @@
 /datum/config_entry/str_list/erp_emotes_to_disable
 
 /datum/config_entry/str_list/erp_emotes_to_disable/ValidateAndSet(str_val)
-	. = ..()
-	if (CONFIG_GET(flag/disable_erp_preferences) && (str_val in GLOB.keybindings_by_name))
-		GLOB.keybindings_by_name -= str_val
+       . = ..()
+       ensure_keybinding_lists()
+       if (CONFIG_GET(flag/disable_erp_preferences) && (str_val in GLOB.keybindings_by_name))
+               GLOB.keybindings_by_name -= str_val
 
 /datum/preference/toggle/master_erp_preferences
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES

--- a/modular_zzplurt/code/datums/components/crafting/crafting.dm
+++ b/modular_zzplurt/code/datums/components/crafting/crafting.dm
@@ -1,5 +1,6 @@
 /datum/component/personal_crafting/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
+       ensure_crafting_recipes()
+       . = ..()
 	if(.)
 		return
 


### PR DESCRIPTION
## Summary
- split global datum setup into per-category lazy initializers
- defer emote, crafting, and surgery list generation until needed
- remove hard make_datum_reference_lists call

## Testing
- `bash tools/ci/check_misc.sh`
- `bash tools/ci/check_grep.sh` *(fails: Outdated proc reference use detected in code/modules/client/client_procs.dm)*

------
https://chatgpt.com/codex/tasks/task_e_6891aea49b3883258e963d1211360a36