### PR TITLE
Expand molotov fire spread

### DIFF
--- a/html/changelogs/ChatGPT-PR-molotov.yml
+++ b/html/changelogs/ChatGPT-PR-molotov.yml
@@ -1,0 +1,5 @@
+author: "ChatGPT"
+delete-after: True
+changes:
+  - rscadd: "Molotov cocktails now ignite surrounding tiles, leaving behind spreading flames."
+  - balance: "Molotov cocktail fire radius increased."


### PR DESCRIPTION
## Summary
- Molotov cocktails now ignite surrounding tiles via a new `spread_fire` helper
- Expanded molotov fire radius for greater area damage
