### PR TITLE
Prevent runtimes in addiction quirks and balloon alerts

### DIFF
--- a/code/datums/quirks/negative_quirks/addict.dm
+++ b/code/datums/quirks/negative_quirks/addict.dm
@@ -67,17 +67,18 @@
 		return
 	COOLDOWN_START(src, next_process, process_interval)
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	var/deleted = QDELETED(reagent_instance)
-	var/missing_addiction = FALSE
-	for(var/addiction_type in reagent_instance.addiction_types)
-		if(!LAZYACCESS(human_holder.last_mind?.active_addictions, addiction_type))
-			missing_addiction = TRUE
-	if(deleted || missing_addiction)
-		if(deleted)
-			reagent_instance = new reagent_type()
-		to_chat(quirk_holder, span_danger("You thought you kicked it, but you feel like you're falling back onto bad habits.."))
-		for(var/addiction in reagent_instance.addiction_types)
-			human_holder.last_mind?.add_addiction_points(addiction, 1000) ///Max that shit out
+        var/deleted = isnull(reagent_instance) || QDELETED(reagent_instance)
+        var/missing_addiction = FALSE
+        if(!deleted)
+                for(var/addiction_type in reagent_instance.addiction_types)
+                        if(!LAZYACCESS(human_holder.last_mind?.active_addictions, addiction_type))
+                                missing_addiction = TRUE
+        if(deleted || missing_addiction)
+                if(deleted)
+                        reagent_instance = new reagent_type()
+                to_chat(quirk_holder, span_danger("You thought you kicked it, but you feel like you're falling back onto bad habits.."))
+                for(var/addiction in reagent_instance.addiction_types)
+                        human_holder.last_mind?.add_addiction_points(addiction, 1000) ///Max that shit out
 
 /datum/quirk/item_quirk/addict/junkie
 	name = "Junkie"

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -85,11 +85,14 @@
 	// These two timers are not the same
 	// One manages the relation to the atom that spawned us, the other to the client we're displaying to
 	// We could lose our loc, and still need to talk to our client, so they are done seperately
-	addtimer(CALLBACK(balloon_alert.loc, PROC_REF(forget_balloon_alert), balloon_alert), BALLOON_TEXT_TOTAL_LIFETIME(length_mult))
+        addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(balloon_alert_cleanup), balloon_alert.loc, balloon_alert), BALLOON_TEXT_TOTAL_LIFETIME(length_mult))
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_client), balloon_alert, viewer_client), BALLOON_TEXT_TOTAL_LIFETIME(length_mult))
 
 /atom/proc/forget_balloon_alert(image/balloon_alert)
-	LAZYREMOVE(update_on_z, balloon_alert)
+        LAZYREMOVE(update_on_z, balloon_alert)
+
+/proc/balloon_alert_cleanup(atom/target, image/balloon_alert)
+        target?.forget_balloon_alert(balloon_alert)
 
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT


### PR DESCRIPTION
## Summary
- handle missing reagent instance in addict quirk processing
- avoid scheduling timers with deleted targets in balloon alerts

## Testing
- `tools/build/build.sh --skip-icon-cutter dm` *(fails: Executable not found in $PATH: "DreamMaker")*


------
https://chatgpt.com/codex/tasks/task_e_689b1433207c8325a1a358b8ec1e0837