### PR TITLE
Handle missing mutant bodyparts and empty blooper list

### DIFF
--- a/modular_skyrat/modules/customization/datums/dna.dm
+++ b/modular_skyrat/modules/customization/datums/dna.dm
@@ -82,18 +82,19 @@ GLOBAL_LIST_EMPTY(total_uf_len_by_block)
 		data += sanitize_hexcolor(features["skin_color"], include_crunch = FALSE)
 	else
 		data += random_string(DNA_BLOCK_SIZE_COLOR, GLOB.hex_characters)
-	for(var/key in SSaccessories.genetic_accessories)
-		if(mutant_bodyparts[key] && (mutant_bodyparts[key][MUTANT_INDEX_NAME] in SSaccessories.genetic_accessories[key]))
-			var/list/accessories_for_key = SSaccessories.genetic_accessories[key]
-			data += construct_block(accessories_for_key.Find(mutant_bodyparts[key][MUTANT_INDEX_NAME]), accessories_for_key.len)
-			var/colors_to_randomize = DNA_BLOCKS_PER_FEATURE-1
-			for(var/color in mutant_bodyparts[key][MUTANT_INDEX_COLOR_LIST])
-				colors_to_randomize--
-				data += sanitize_hexcolor(color, include_crunch = FALSE)
-			if(colors_to_randomize)
-				data += random_string(DNA_BLOCK_SIZE_COLOR * colors_to_randomize, GLOB.hex_characters)
-		else
-			data += random_string(DNA_FEATURE_BLOCKS_TOTAL_SIZE_PER_FEATURE, GLOB.hex_characters)
+       for(var/key in SSaccessories.genetic_accessories)
+               var/list/part = mutant_bodyparts[key]
+               if(part && (part[MUTANT_INDEX_NAME] in SSaccessories.genetic_accessories[key]))
+                       var/list/accessories_for_key = SSaccessories.genetic_accessories[key]
+                       data += construct_block(accessories_for_key.Find(part[MUTANT_INDEX_NAME]), accessories_for_key.len)
+                       var/colors_to_randomize = DNA_BLOCKS_PER_FEATURE - 1
+                       for(var/color in part[MUTANT_INDEX_COLOR_LIST])
+                               colors_to_randomize--
+                               data += sanitize_hexcolor(color, include_crunch = FALSE)
+                       if(colors_to_randomize)
+                               data += random_string(DNA_BLOCK_SIZE_COLOR * colors_to_randomize, GLOB.hex_characters)
+               else
+                       data += random_string(DNA_FEATURE_BLOCKS_TOTAL_SIZE_PER_FEATURE, GLOB.hex_characters)
 	for(var/zone in GLOB.marking_zones)
 		if(body_markings[zone])
 			data += construct_block(body_markings[zone].len+1, MAXIMUM_MARKINGS_PER_LIMB+1)
@@ -181,8 +182,8 @@ GLOBAL_LIST_EMPTY(total_uf_len_by_block)
 /mob/living/carbon/proc/apply_customizable_dna_features_to_species()
 	if(!has_dna())
 		CRASH("[src] does not have DNA")
-	dna.species.body_markings = dna.body_markings.Copy()
-	var/list/bodyparts_to_add = dna.mutant_bodyparts.Copy()
+       dna.species.body_markings = dna.body_markings.Copy()
+       var/list/bodyparts_to_add = LAZYLEN(dna.mutant_bodyparts) ? dna.mutant_bodyparts.Copy() : list()
 	for(var/key in bodyparts_to_add)
 		if(SSaccessories.sprite_accessories[key] && bodyparts_to_add[key] && bodyparts_to_add[key][MUTANT_INDEX_NAME])
 			var/datum/sprite_accessory/SP = SSaccessories.sprite_accessories[key][bodyparts_to_add[key][MUTANT_INDEX_NAME]]

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -96,8 +96,10 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	var/list/mutantpart_list = list()
 	if(LAZYLEN(existing_mutant_bodyparts))
 		mutantpart_list = existing_mutant_bodyparts.Copy()
-	var/list/default_bodypart_data = GLOB.default_mutant_bodyparts[name]
-	var/list/bodyparts_to_add = default_bodypart_data.Copy()
+       var/list/default_bodypart_data = GLOB.default_mutant_bodyparts[name]
+       if(!LAZYLEN(default_bodypart_data))
+               return mutantpart_list
+       var/list/bodyparts_to_add = default_bodypart_data.Copy()
 	if(CONFIG_GET(flag/disable_erp_preferences))
 		for(var/genital in GLOB.possible_genitals)
 			bodyparts_to_add.Remove(genital)

--- a/modular_zubbers/code/modules/blooper/atoms_movable.dm
+++ b/modular_zubbers/code/modules/blooper/atoms_movable.dm
@@ -55,13 +55,13 @@ It has also been further modified by Rashcat & other Fluffyfrontier contributors
 			total_delay += rand(DS2TICKS(blooper_speed / BLOOPER_SPEED_BASELINE), DS2TICKS(blooper_speed / BLOOPER_SPEED_BASELINE) + DS2TICKS(blooper_speed / BLOOPER_SPEED_BASELINE)) TICKS
 
 /mob/living/carbon/human/Initialize(mapload)
-	. = ..()
-	// This gives a random vocal bark to a random created person
-	if(!client)
-		set_blooper(pick(GLOB.blooper_list))
-		blooper_pitch = BLOOPER_PITCH_RAND(gender)
-		blooper_pitch_range = BLOOPER_VARIANCE_RAND
-		blooper_speed = rand(BLOOPER_DEFAULT_MINSPEED, BLOOPER_DEFAULT_MAXSPEED)
+       . = ..()
+       // This gives a random vocal bark to a random created person
+       if(!client && LAZYLEN(GLOB.blooper_list))
+               set_blooper(pick(GLOB.blooper_list))
+               blooper_pitch = BLOOPER_PITCH_RAND(gender)
+               blooper_pitch_range = BLOOPER_VARIANCE_RAND
+               blooper_speed = rand(BLOOPER_DEFAULT_MINSPEED, BLOOPER_DEFAULT_MAXSPEED)
 
 /mob/living/send_speech(message_raw, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language = null, list/message_mods = list(), forced = null, tts_message, list/tts_filter)
 	. = ..()


### PR DESCRIPTION
## Summary
- Avoid null accesses when building mutant bodyparts
- Safely copy DNA features for species
- Skip assigning bloopers if none exist

## Testing
- `bash tools/build/build.sh` *(fails: Failed to download https://github.com/spacestation13/hypnagogic/releases/download/v4.0.0/hypnagogic: Status 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b26142ff0832594ce5ee27eb22729