### PR TITLE
Handle empty emote preference lists

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/laugh.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/laugh.dm
@@ -4,7 +4,17 @@
 	savefile_key = "character_laugh"
 
 /datum/preference/choiced/laugh/init_possible_values()
-	return assoc_to_keys(GLOB.laugh_types)
+        return assoc_to_keys(GLOB.laugh_types)
+
+/datum/preference/choiced/laugh/create_default_value()
+        if(!length(GLOB.laugh_types))
+                return null
+        return pick(assoc_to_keys(GLOB.laugh_types))
+
+/datum/preference/choiced/laugh/is_valid(value)
+        if(!length(GLOB.laugh_types))
+                return TRUE
+        return ..()
 
 /datum/preference/choiced/laugh/apply_to_human(mob/living/carbon/human/target, value)
 	var/laugh_id = GLOB.laugh_types[value]

--- a/modular_skyrat/master_files/code/modules/client/preferences/scream.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/scream.dm
@@ -4,7 +4,17 @@
 	savefile_key = "character_scream"
 
 /datum/preference/choiced/scream/init_possible_values()
-	return assoc_to_keys(GLOB.scream_types)
+        return assoc_to_keys(GLOB.scream_types)
+
+/datum/preference/choiced/scream/create_default_value()
+        if(!length(GLOB.scream_types))
+                return null
+        return pick(assoc_to_keys(GLOB.scream_types))
+
+/datum/preference/choiced/scream/is_valid(value)
+        if(!length(GLOB.scream_types))
+                return TRUE
+        return ..()
 
 /datum/preference/choiced/scream/apply_to_human(mob/living/carbon/human/target, value)
 	var/scream_id = GLOB.scream_types[value]

--- a/modular_zubbers/code/modules/blooper/bark.dm
+++ b/modular_zubbers/code/modules/blooper/bark.dm
@@ -56,7 +56,17 @@ GLOBAL_VAR_INIT(blooper_allowed, TRUE) // For administrators
 	savefile_key = "blooper_speech"
 
 /datum/preference/choiced/blooper/init_possible_values()
-	return assoc_to_keys(GLOB.blooper_list)
+        return assoc_to_keys(GLOB.blooper_list)
+
+/datum/preference/choiced/blooper/create_default_value()
+        if(!length(GLOB.blooper_list))
+                return null
+        return pick(assoc_to_keys(GLOB.blooper_list))
+
+/datum/preference/choiced/blooper/is_valid(value)
+        if(!length(GLOB.blooper_list))
+                return TRUE
+        return ..()
 
 /datum/preference/choiced/blooper/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_blooper(value)


### PR DESCRIPTION
## Summary
- avoid runtime when laugh/scream/blooper lists are empty