### PR TITLE
Fix ore bag module not dropping ore

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -203,8 +203,11 @@
 	ores += ore
 
 /obj/item/mod/module/orebag/on_use()
-	for(var/obj/item/ore as anything in ores)
-		ore.forceMove(drop_location())
+	var/atom/drop_loc = mod?.wearer?.drop_location() || drop_location()
+	if(!drop_loc)
+		return
+	for(var/obj/item/stack/ore/ore as anything in ores)
+		ore.forceMove(drop_loc)
 		ores -= ore
 	drain_power(use_energy_cost)
 

--- a/html/changelogs/ChatGPT-PR-orebag.yml
+++ b/html/changelogs/ChatGPT-PR-orebag.yml
@@ -1,0 +1,4 @@
+author: "ChatGPT"
+delete-after: True
+changes:
+  - bugfix: "MOD ore bag module now drops stored ore when activated."


### PR DESCRIPTION
## Summary
- Ensure MOD ore bag uses wearer's drop location when dumping stored ore
- Document fix in changelog

## Testing
- `bash tools/ci/install_spaceman_dmm.sh DreamChecker` *(fails: Proxy tunneling failed: Forbidden)*
- `bash tools/ci/build_spaceman_dmm.sh DreamChecker` *(fails: SPACEMAN_DMM_COMMIT_HASH: unbound variable)*

------
https://chatgpt.com/codex/tasks/task_e_689b52a0da7883258c08f9f04fd7358c