### PR TITLE
Prevent config Get before configuration loads

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -306,10 +306,12 @@
 	return msg
 
 /datum/controller/configuration/proc/Get(entry_type)
-	var/datum/config_entry/E = entry_type
-	var/entry_is_abstract = initial(E.abstract_type) == entry_type
-	if(entry_is_abstract)
-		CRASH("Tried to retrieve an abstract config_entry: [entry_type]")
+        var/datum/config_entry/E = entry_type
+        var/entry_is_abstract = initial(E.abstract_type) == entry_type
+        if(entry_is_abstract)
+                CRASH("Tried to retrieve an abstract config_entry: [entry_type]")
+	if(!loaded || !entries_by_type)
+		return initial(entry_type.default)
 	E = entries_by_type[entry_type]
 	if(!E)
 		CRASH("Missing config entry for [entry_type]!")


### PR DESCRIPTION
## Summary
- avoid runtimes in Configuration.Get by returning defaults when the configuration isn't loaded yet
