### PR TITLE
fix: allow moth antennae to be hidden

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/moth_antennae.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/moth_antennae.dm
@@ -6,8 +6,8 @@
 	organ_type = /obj/item/organ/antennae
 
 /datum/sprite_accessory/moth_antennae/is_hidden(mob/living/carbon/human/wearer)
-	if(!wearer.head)
-		return FALSE
+       if(!wearer.head && !wearer.wear_mask)
+               return FALSE
 
 	// Can hide if wearing hat
 	if(key in wearer.try_hide_mutant_parts)


### PR DESCRIPTION
## Summary
- allow moth antennae to be hidden via the Hide Mutant Parts verb when wearing a mask
