### PR TITLE
Deduplicate alt job titles

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -153,6 +153,10 @@
 	if(isnum(new_total_positions))
 		total_positions = new_total_positions
 
+	if(length(alt_titles))
+		alt_titles -= title
+		unique_list_in_place(alt_titles)
+
 /// Executes after the mob has been spawned in the map. Client might not be yet in the mob, and is thus a separate variable.
 /datum/job/proc/after_spawn(mob/living/spawned, client/player_client)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
## Summary
- prevent duplicate titles in alt job title lists

## Testing
- `./tools/build/build.sh dm` *(fails: Failed to download https://github.com/spacestation13/hypnagogic/releases/download/v4.0.0/hypnagogic: Status 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ba7a18cd08325a407d8d12265266d