### PR TITLE
feat: enhance molotov fire effects

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -571,12 +571,28 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 		var/mob/living/enflamed_liver = enflammable_atom
 		if(enflamed_liver.on_fire)
 			ignite()
-	else if(istype(enflammable_atom, /obj/effect/particle_effect/sparks))
-		ignite()
+        else if(istype(enflammable_atom, /obj/effect/particle_effect/sparks))
+                ignite()
 
+/obj/effect/hotspot/molotov
+        volume = 250
+
+/obj/effect/decal/cleanable/fuel_pool/molotov
+        burn_amount = 8
+        hotspot_type = /obj/effect/hotspot/molotov
+
+/obj/effect/decal/cleanable/fuel_pool/molotov/Initialize(mapload, burn_stacks)
+        . = ..(mapload, burn_stacks)
+        if(. != INITIALIZE_HINT_QDEL)
+                ignite()
+        return .
+
+/obj/effect/decal/cleanable/fuel_pool/molotov/Destroy()
+        new /obj/effect/temp_visual/small_smoke/long(get_turf(src))
+        return ..()
 
 /obj/effect/decal/cleanable/fuel_pool/hivis
-	icon_state = "fuel_pool_hivis"
+icon_state = "fuel_pool_hivis"
 
 /obj/effect/decal/cleanable/rubble
 	name = "rubble"

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -259,11 +259,14 @@
 	duration = 5
 
 /obj/effect/temp_visual/small_smoke
-	icon_state = "smoke"
-	duration = 50
+        icon_state = "smoke"
+        duration = 50
 
 /obj/effect/temp_visual/small_smoke/halfsecond
-	duration = 5
+        duration = 5
+
+/obj/effect/temp_visual/small_smoke/long
+        duration = 200
 
 /obj/effect/temp_visual/fire
 	icon = 'icons/effects/fire.dmi'

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -927,10 +927,10 @@
 	return ..()
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/proc/spread_fire(atom/center)
-	for(var/turf/nearby_turf as anything in RANGE_TURFS(fire_radius, center))
-		for(var/atom/thing in nearby_turf)
-			thing.fire_act()
-		new /obj/effect/hotspot(nearby_turf)
+        for(var/turf/nearby_turf as anything in RANGE_TURFS(fire_radius, center))
+                for(var/atom/thing in nearby_turf)
+                        thing.fire_act()
+                new /obj/effect/decal/cleanable/fuel_pool/molotov(nearby_turf)
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum, do_splash = FALSE)
 	..(hit_atom, throwingdatum, do_splash = FALSE)
@@ -947,14 +947,15 @@
 		spread_fire(target)
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	if(I.get_temperature() && !active)
-		active = TRUE
-		log_bomber(user, "has primed a", src, "for detonation")
+        if(I.get_temperature() && !active)
+                active = TRUE
+                log_bomber(user, "has primed a", src, "for detonation")
 
-		to_chat(user, span_info("You light [src] on fire."))
-		add_overlay(custom_fire_overlay() || GLOB.fire_overlay)
-		if(!isGlass)
-			addtimer(CALLBACK(src, PROC_REF(explode)), 5 SECONDS)
+                to_chat(user, span_info("You light [src] on fire."))
+                add_overlay(custom_fire_overlay() || GLOB.fire_overlay)
+                AddElement(/datum/element/effect_trail, /obj/effect/decal/cleanable/fuel_pool/molotov)
+                if(!isGlass)
+                        addtimer(CALLBACK(src, PROC_REF(explode)), 5 SECONDS)
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/proc/explode()
 	if(!active)


### PR DESCRIPTION
## Summary
- make molotovs leave burning fuel trails and longer-lasting fire
- add lingering smoke after molotov fires burn out

## Testing
- `bash tools/ci/check_misc.sh`
- `bash tools/ci/check_changelogs.sh` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689cf14c45ec8325998f4ef082c08ded