### PR TITLE
feat: rework molotov fire behavior

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -571,12 +571,39 @@ GLOBAL_LIST_EMPTY(nebula_vomits)
 		var/mob/living/enflamed_liver = enflammable_atom
 		if(enflamed_liver.on_fire)
 			ignite()
-	else if(istype(enflammable_atom, /obj/effect/particle_effect/sparks))
-		ignite()
+        else if(istype(enflammable_atom, /obj/effect/particle_effect/sparks))
+                ignite()
 
+/obj/effect/hotspot/molotov
+    volume = 250
+
+/obj/effect/hotspot/molotov/Initialize(mapload, starting_volume, starting_temperature)
+    . = ..()
+    particles = new /particles/embers/spark()
+    add_shared_particles(/particles/smoke/burning)
+    return .
+
+/obj/effect/hotspot/molotov/Destroy()
+    remove_shared_particles(/particles/smoke/burning)
+    return ..()
+
+/obj/effect/decal/cleanable/fuel_pool/molotov
+        burn_amount = 8
+        hotspot_type = /obj/effect/hotspot/molotov
+
+/obj/effect/decal/cleanable/fuel_pool/molotov/Initialize(mapload, burn_stacks)
+        . = ..(mapload, burn_stacks)
+        if(. != INITIALIZE_HINT_QDEL)
+                ignite()
+        return .
+
+/obj/effect/decal/cleanable/fuel_pool/molotov/Destroy()
+    var/obj/effect/particle_effect/fluid/smoke/smoke = new(get_turf(src))
+    smoke.lifetime = 20 SECONDS
+    return ..()
 
 /obj/effect/decal/cleanable/fuel_pool/hivis
-	icon_state = "fuel_pool_hivis"
+icon_state = "fuel_pool_hivis"
 
 /obj/effect/decal/cleanable/rubble
 	name = "rubble"

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -902,8 +902,8 @@
 	icon_state = "vodkabottle"
 	list_reagents = list()
 	var/active = FALSE
-	/// how far the resulting fire spreads
-	var/fire_radius = 2
+    /// how far the resulting fire spreads
+    var/fire_radius = 4
 	var/list/accelerants = list(
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/fuel,
@@ -927,10 +927,13 @@
 	return ..()
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/proc/spread_fire(atom/center)
-	for(var/turf/nearby_turf as anything in RANGE_TURFS(fire_radius, center))
-		for(var/atom/thing in nearby_turf)
-			thing.fire_act()
-		new /obj/effect/hotspot(nearby_turf)
+    var/turf/center_turf = get_turf(center)
+    for(var/turf/nearby_turf as anything in RANGE_TURFS(fire_radius, center_turf))
+        var/dist = get_dist(center_turf, nearby_turf)
+        if(prob(max(10, 100 - dist * 25)))
+            for(var/atom/thing in nearby_turf)
+                thing.fire_act()
+            new /obj/effect/decal/cleanable/fuel_pool/molotov(nearby_turf)
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum, do_splash = FALSE)
 	..(hit_atom, throwingdatum, do_splash = FALSE)
@@ -947,14 +950,14 @@
 		spread_fire(target)
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/attackby(obj/item/I, mob/user, list/modifiers, list/attack_modifiers)
-	if(I.get_temperature() && !active)
-		active = TRUE
-		log_bomber(user, "has primed a", src, "for detonation")
+        if(I.get_temperature() && !active)
+                active = TRUE
+                log_bomber(user, "has primed a", src, "for detonation")
 
-		to_chat(user, span_info("You light [src] on fire."))
-		add_overlay(custom_fire_overlay() || GLOB.fire_overlay)
-		if(!isGlass)
-			addtimer(CALLBACK(src, PROC_REF(explode)), 5 SECONDS)
+        to_chat(user, span_info("You light [src] on fire."))
+        add_overlay(custom_fire_overlay() || GLOB.fire_overlay)
+        if(!isGlass)
+            addtimer(CALLBACK(src, PROC_REF(explode)), 5 SECONDS)
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/proc/explode()
 	if(!active)


### PR DESCRIPTION
## Summary
- use ember and smoke particles for molotov fires
- widen molotov splash and ignite only when the bottle shatters
- remove obsolete long-lived smoke temp visual