### PR TITLE
Fix Molotov bottles failing to break on floor impact

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -119,7 +119,7 @@
 	volume = 50
 	custom_price = PAYCHECK_CREW * 0.9
 
-/obj/item/reagent_containers/cup/glass/bottle/smash(mob/living/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
+/obj/item/reagent_containers/cup/glass/bottle/smash(atom/target, mob/thrower, datum/thrownthing/throwingdatum, break_top)
 	if(bartender_check(target, thrower) && throwingdatum)
 		return
 	SplashReagents(target, throwingdatum, override_spillable = TRUE)


### PR DESCRIPTION
## Summary
- ensure Molotov bottles shatter on any collision

## Testing
- `DreamMaker tgstation.dme` *(fails: command not found)*
- `bash tools/ci/check_misc.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d9953a674832591516fa2a148857d