### PR TITLE
Spawn configuration tasks to reduce startup delay

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -133,9 +133,9 @@ GLOBAL_VAR(restart_counter)
 
 	// First possible sleep()
 	spawn() InitTgs()
-	
+
 	config.Load(params[OVERRIDE_CONFIG_DIRECTORY_PARAMETER])
-	
+
 	ConfigLoaded()
 
 	if(NO_INIT_PARAMETER in params)
@@ -148,16 +148,16 @@ GLOBAL_VAR(restart_counter)
 	SSredbot.Initialize()
 
 /// Initializes TGS and loads the returned revising info into GLOB.revdata
-	/world/proc/InitTgs()
+/world/proc/InitTgs()
 	set waitfor = 0
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED)
 	GLOB.revdata.load_tgs_info()
 
 /// Runs after config is loaded but before Master is initialized
-	/world/proc/ConfigLoaded()
+/world/proc/ConfigLoaded()
 	// Everything in here is prioritized in a very specific way.
 	// If you need to add to it, ask yourself hard if what you're adding is in the right spot
-	
+
 	// Try to set round ID without blocking the main thread
 	spawn() SSdbcore.InitializeRound()
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -132,10 +132,10 @@ GLOBAL_VAR(restart_counter)
 	GLOB.timezoneOffset = world.timezone * 36000
 
 	// First possible sleep()
-	InitTgs()
-
+	spawn() InitTgs()
+	
 	config.Load(params[OVERRIDE_CONFIG_DIRECTORY_PARAMETER])
-
+	
 	ConfigLoaded()
 
 	if(NO_INIT_PARAMETER in params)
@@ -148,28 +148,30 @@ GLOBAL_VAR(restart_counter)
 	SSredbot.Initialize()
 
 /// Initializes TGS and loads the returned revising info into GLOB.revdata
-/world/proc/InitTgs()
+	/world/proc/InitTgs()
+	set waitfor = 0
 	TgsNew(new /datum/tgs_event_handler/impl, TGS_SECURITY_TRUSTED)
 	GLOB.revdata.load_tgs_info()
 
 /// Runs after config is loaded but before Master is initialized
-/world/proc/ConfigLoaded()
-        // Everything in here is prioritized in a very specific way.
-        // If you need to add to it, ask yourself hard if what you're adding is in the right spot
+	/world/proc/ConfigLoaded()
+	// Everything in here is prioritized in a very specific way.
+	// If you need to add to it, ask yourself hard if what you're adding is in the right spot
+	
+	// Try to set round ID without blocking the main thread
+	spawn() SSdbcore.InitializeRound()
 
-	// Try to set round ID
-	SSdbcore.InitializeRound()
+	spawn() SetupLogs()
 
-	SetupLogs()
+	spawn() load_admins(initial = TRUE)
 
-	load_admins(initial = TRUE)
+	spawn() LoadVerbCache()
+	spawn() LoadVerbs(/datum/verbs/menu)
 
-	LoadVerbCache()
-	LoadVerbs(/datum/verbs/menu)
-
-	if(fexists(RESTART_COUNTER_PATH))
-		GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))
-		fdel(RESTART_COUNTER_PATH)
+	spawn()
+		if(fexists(RESTART_COUNTER_PATH))
+			GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))
+			fdel(RESTART_COUNTER_PATH)
 
 /// Runs after the call to Master.Initialize, but before the delay kicks in. Used to turn the world execution into some single function then exit
 /world/proc/RunUnattendedFunctions()


### PR DESCRIPTION
## Summary
- initialize the TGS API asynchronously during world startup
- schedule logging, admin loading, and other configuration tasks to run in the background
- spawn round ID setup and restart counter loading to avoid blocking startup

## Testing
- `bash tools/ci/check_grep.sh` *(fails: Errors found, please fix them and try again)*

------
https://chatgpt.com/codex/tasks/task_e_68a22d5b042c8325a2efa0de1a63da5a