### PR TITLE
Cache accessory mutable appearances

### DIFF
--- a/code/controllers/subsystem/sprite_accessories.dm
+++ b/code/controllers/subsystem/sprite_accessories.dm
@@ -73,13 +73,13 @@ SUBSYSTEM_DEF(accessories) // just 'accessories' for brevity
 	var/list/caps_list
 	var/list/moth_wings_list
 
-        var/list/sprite_accessories = list()
-        var/list/genetic_accessories = list()
-        var/list/generic_accessories = list()
+	var/list/sprite_accessories = list()
+	var/list/genetic_accessories = list()
+	var/list/generic_accessories = list()
 
-       var/list/cached_mutant_icon_files = list()
-       /// Cached mutable appearances keyed by accessory information
-       var/list/accessory_icon_cache = list()
+	var/list/cached_mutant_icon_files = list()
+	/// Cached mutable appearances keyed by accessory information
+	var/list/accessory_icon_cache = list()
 
 	// we are loading them along with sprite_accessories, so they can't be GLOB :(
 	var/dna_total_feature_blocks = DNA_MANDATORY_COLOR_BLOCKS
@@ -211,26 +211,26 @@ SUBSYSTEM_DEF(accessories) // just 'accessories' for brevity
 				returnable_list[MALE_SPRITE_LIST] += accessory.name
 				returnable_list[FEMALE_SPRITE_LIST] += accessory.name
 
-        if(add_blank)
-                returnable_list[DEFAULT_SPRITE_LIST][SPRITE_ACCESSORY_NONE] = new /datum/sprite_accessory/blank
+	if(add_blank)
+		returnable_list[DEFAULT_SPRITE_LIST][SPRITE_ACCESSORY_NONE] = new /datum/sprite_accessory/blank
 
-        return returnable_list
+		return returnable_list
 
 /datum/controller/subsystem/accessories/proc/get_cached_appearance(icon, icon_state, key, layer = null)
-       var/cache_key = "[key]-[icon]-[icon_state]-[layer]"
-       var/mutable_appearance/appearance = accessory_icon_cache[cache_key]
-       if(!appearance)
-               appearance = mutable_appearance(icon, icon_state, layer)
-               accessory_icon_cache[cache_key] = appearance
-       return appearance
+	var/cache_key = "[key]-[icon]-[icon_state]-[layer]"
+	var/mutable_appearance/appearance = accessory_icon_cache[cache_key]
+	if(!appearance)
+		appearance = mutable_appearance(icon, icon_state, layer)
+		accessory_icon_cache[cache_key] = appearance
+	return appearance
 
 /datum/controller/subsystem/accessories/proc/invalidate_accessory_cache(key)
-       for(var/cache_key in accessory_icon_cache)
-               if(findtext(cache_key, "[key]-") == 1)
-                       accessory_icon_cache -= cache_key
+	for(var/cache_key in accessory_icon_cache)
+		if(findtext(cache_key, "[key]-") == 1)
+			accessory_icon_cache -= cache_key
 
 /datum/controller/subsystem/accessories/proc/reset_accessory_cache()
-       accessory_icon_cache.Cut()
+	accessory_icon_cache.Cut()
 
 #undef DEFAULT_SPRITE_LIST
 #undef MALE_SPRITE_LIST

--- a/modular_skyrat/modules/customization/modules/clothing/masks/paper.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/masks/paper.dm
@@ -62,9 +62,9 @@
 		alternate_worn_layer = BACK_LAYER
 
 /obj/item/clothing/mask/paper/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
-       . = ..()
-       if(!strap_hidden)
-               . += SSaccessories.get_cached_appearance(icon_file, "mask_paper_strap", "paper_mask_strap")
+	. = ..()
+	if(!strap_hidden)
+		. += SSaccessories.get_cached_appearance(icon_file, "mask_paper_strap", "paper_mask_strap")
 
 /obj/item/clothing/mask/paper/click_alt_secondary(mob/user)
 		adjust_mask(user)

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -49,12 +49,12 @@
 	var/erp_accessory = FALSE
 
 /datum/sprite_accessory/New()
-       if(SSaccessories && key)
-               SSaccessories.invalidate_accessory_cache(key)
-       if(!default_color)
-               switch(color_src)
-                       if(USE_ONE_COLOR)
-                               default_color = DEFAULT_PRIMARY
+	if(SSaccessories && key)
+		SSaccessories.invalidate_accessory_cache(key)
+	if(!default_color)
+		switch(color_src)
+			if(USE_ONE_COLOR)
+				default_color = DEFAULT_PRIMARY
 			if(USE_MATRIXED_COLORS)
 				default_color = DEFAULT_MATRIXED
 			else

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -196,10 +196,10 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	*/
 	//SPLURT EDIT END
 	//SPLURT ADDITION START - Nails
-       if(species_human.nail_style)
-               var/mutable_appearance/nail_overlay = SSaccessories.get_cached_appearance('modular_zzplurt/icons/mobs/nails.dmi', "nails", "nail_overlay", -BODY_LAYER)
-               nail_overlay.color = species_human.nail_color
-               standing += nail_overlay
+	if(species_human.nail_style)
+		var/mutable_appearance/nail_overlay = SSaccessories.get_cached_appearance('modular_zzplurt/icons/mobs/nails.dmi', "nails", "nail_overlay", -BODY_LAYER)
+		nail_overlay.color = species_human.nail_color
+		standing += nail_overlay
 	//SPLURT ADDITION END - Nails
 
 	if(standing.len)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/worn_overlays.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/worn_overlays.dm
@@ -11,10 +11,10 @@
 	if(OFFSET_ACCESSORY in human_wearer.dna.species.custom_worn_icons)
 		var/icon/custom_accessory_icon = human_wearer.dna.species.custom_worn_icons[OFFSET_ACCESSORY]
 
-               var/list/custom_accessory_states = icon_states(custom_accessory_icon)
-               if(accessory_overlay.icon_state in custom_accessory_states)
-                       // Make new appearance so we don't break the real accessory overlay for other species, and treat it as final.
-                       return SSaccessories.get_cached_appearance(custom_accessory_icon, accessory_overlay.icon_state, "custom")
+		var/list/custom_accessory_states = icon_states(custom_accessory_icon)
+		if(accessory_overlay.icon_state in custom_accessory_states)
+			// Make new appearance so we don't break the real accessory overlay for other species, and treat it as final.
+			return SSaccessories.get_cached_appearance(custom_accessory_icon, accessory_overlay.icon_state, "custom")
 
 	var/obj/item/bodypart/chest/my_chest = human_wearer.get_bodypart(BODY_ZONE_CHEST)
 	my_chest?.worn_accessory_offset?.apply_offset(accessory_overlay)

--- a/modular_skyrat/modules/customization/subsytem/sprite_accessories.dm
+++ b/modular_skyrat/modules/customization/subsytem/sprite_accessories.dm
@@ -2,8 +2,8 @@
  * Called from subsystem's PreInit and builds sprite_accessories list with (almost) all existing sprite accessories
  */
 /datum/controller/subsystem/accessories/proc/make_sprite_accessory_references()
-       reset_accessory_cache()
-       for(var/path in subtypesof(/datum/sprite_accessory))
+	reset_accessory_cache()
+	for(var/path in subtypesof(/datum/sprite_accessory))
 		var/datum/sprite_accessory/P = path
 		if(initial(P.key) && initial(P.name))
 			P = new path()


### PR DESCRIPTION
## Summary
- cache sprite accessory mutable appearances globally
- use cached accessory appearances instead of recomputing each call
- clear cached accessory data when definitions change