### PR TITLE
Lazy vending inventory and shared icon cache

### DIFF
--- a/code/controllers/subsystem/vending_icon_cache.dm
+++ b/code/controllers/subsystem/vending_icon_cache.dm
@@ -1,0 +1,18 @@
+SUBSYSTEM_DEF(vending_icon_cache)
+
+/datum/controller/subsystem/vending_icon_cache
+	name = "Vending Icon Cache"
+	flags = SS_NO_FIRE
+	var/list/icon_states_cache = list()
+
+/datum/controller/subsystem/vending_icon_cache/Initialize()
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/vending_icon_cache/proc/get_icon_states(icon_file)
+	if(isnull(icon_file))
+		return list()
+	var/list/cached = icon_states_cache[icon_file]
+	if(isnull(cached))
+		cached = icon_states(icon_file)
+		icon_states_cache[icon_file] = cached
+	return cached

--- a/code/modules/asset_cache/assets/vending.dm
+++ b/code/modules/asset_cache/assets/vending.dm
@@ -6,6 +6,7 @@
 	var/target_items = list()
 	for(var/obj/machinery/vending/vendor as anything in subtypesof(/obj/machinery/vending))
 		vendor = new vendor() // It seems `initial(list var)` has nothing. need to make a type.
+		vendor.build_products_from_categories()
 		target_items |= vendor.products
 		target_items |= vendor.premium
 		target_items |= vendor.contraband
@@ -32,7 +33,7 @@
 			if (!has_gags && !icon_exists(initial(item.icon), icon_state))
 				var/icon_file = initial(item.icon)
 				var/icon_states_string
-				for (var/an_icon_state in icon_states(icon_file))
+				for (var/an_icon_state in SSvending_icon_cache.get_icon_states(icon_file))
 					if (!icon_states_string)
 						icon_states_string = "[json_encode(an_icon_state)]([text_ref(an_icon_state)])"
 					else

--- a/modular_zubbers/code/modules/species_refits_awareness/code/refithelper.dm
+++ b/modular_zubbers/code/modules/species_refits_awareness/code/refithelper.dm
@@ -50,7 +50,7 @@
 			refit_path = "modular_skyrat/master_files/icons/mob/clothing/species/[cur_species]/[item_slot].dmi"
 			if(!fexists(refit_path))
 				break
-			icons_in_refit_path = icon_states(refit_path)
+			icons_in_refit_path = SSvending_icon_cache.get_icon_states(refit_path)
 			if(icons_in_refit_path.Find(icon_state))
 				available_refits += cur_species
 		else


### PR DESCRIPTION
## Summary
- Delay vending machine inventory construction until first use
- Add SSvending_icon_cache to share icon state loads
- Respect lazy init in restock and construction routines

## Testing
- `bash tools/ci/check_grep.sh` *(fails: space indentation in unrelated files)*
- `bash tools/ci/check_misc.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a25370b1388325999fbdd487ad1c48