### PR TITLE
Defer portable turret setup to LateInitialize

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -115,27 +115,36 @@ DEFINE_BITFIELD(turret_flags, list(
 	fire = 90
 	acid = 90
 
+// Initialization is kept light to avoid expensive work during map load.
+// Heavy setup is deferred to LateInitialize.
 /obj/machinery/porta_turret/Initialize(mapload)
-	. = ..()
-	if(!base)
-		base = src
-	update_appearance()
-	//Sets up a spark system
-	spark_system = new /datum/effect_system/spark_spread
-	spark_system.set_up(5, 0, src)
-	spark_system.attach(src)
+       . = ..()
+       if(!base)
+               base = src
 
-	setup()
-	if(has_cover)
-		cover = new /obj/machinery/porta_turret_cover(loc)
-		cover.parent_turret = src
-		var/mutable_appearance/base = mutable_appearance('icons/obj/weapons/turrets.dmi', "basedark")
-		base.layer = NOT_HIGH_OBJ_LAYER
-		underlays += base
-	if(!has_cover)
-		INVOKE_ASYNC(src, PROC_REF(popUp))
+       AddElement(/datum/element/hostile_machine)
 
-	AddElement(/datum/element/hostile_machine)
+       return .
+
+/obj/machinery/porta_turret/LateInitialize()
+       . = ..()
+
+       //Sets up a spark system
+       spark_system = new /datum/effect_system/spark_spread
+       spark_system.set_up(5, 0, src)
+       spark_system.attach(src)
+
+       if(!stored_gun)
+               setup()
+
+       if(has_cover)
+               cover = new /obj/machinery/porta_turret_cover(loc)
+               cover.parent_turret = src
+               var/mutable_appearance/base = mutable_appearance('icons/obj/weapons/turrets.dmi', "basedark")
+               base.layer = NOT_HIGH_OBJ_LAYER
+               underlays += base
+
+       update_appearance()
 
 ///Toggles the turret on or off depending on the value of the turn_on arg.
 /obj/machinery/porta_turret/proc/toggle_on(turn_on = TRUE)
@@ -876,9 +885,13 @@ DEFINE_BITFIELD(turret_flags, list(
 	return
 
 /obj/machinery/porta_turret/aux_base/Initialize(mapload)
-	. = ..()
-	cover.name = name
-	cover.desc = desc
+       return ..()
+
+/obj/machinery/porta_turret/aux_base/LateInitialize()
+       . = ..()
+       if(cover)
+               cover.name = name
+               cover.desc = desc
 
 /obj/machinery/porta_turret/centcom_shuttle
 	installation = null


### PR DESCRIPTION
## Summary
- Move portable turret construction from `Initialize()` to `LateInitialize()`
- Only pop up turrets after activation
- Delay aux-base cover configuration to `LateInitialize`

## Testing
- `bash tools/ci/check_grep.sh` (fails: "Errors found, please fix them and try again")
- `bash tools/ci/install_byond.sh` (fails: cannot find byond.zip)


------
https://chatgpt.com/codex/tasks/task_e_68a2536a4d6483258637f8ba92b24a90