### PR TITLE
Lazy-load library shelves

### DIFF
--- a/code/controllers/subsystem/library.dm
+++ b/code/controllers/subsystem/library.dm
@@ -25,8 +25,11 @@ SUBSYSTEM_DEF(library)
 /datum/controller/subsystem/library/Initialize()
 	prepare_official_posters()
 	prepare_library_areas()
-	load_shelves()
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/library/proc/lazy_load_shelves()
+	if(shelves_to_load)
+		load_shelves()
 
 /datum/controller/subsystem/library/proc/load_shelves()
 	var/list/datum/callback/load_callbacks = list()
@@ -43,6 +46,7 @@ SUBSYSTEM_DEF(library)
 
 /// Returns a list of copied book datums that we consider to be "in" the passed in area at roundstart
 /datum/controller/subsystem/library/proc/get_area_books(area/book_parent)
+	lazy_load_shelves()
 	var/list/areas = list(book_parent.type)
 	// If we have an area that's in the global libraries list, we want all the others too
 	if(length(areas & library_areas))

--- a/code/modules/library/bookcase.dm
+++ b/code/modules/library/bookcase.dm
@@ -195,6 +195,7 @@
 	return ..()
 
 /obj/structure/bookcase/attack_hand(mob/living/user, list/modifiers)
+	SSlibrary.lazy_load_shelves()
 	. = ..()
 	if(.)
 		return

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -60,12 +60,14 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 
 /obj/machinery/computer/libraryconsole/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
+	SSlibrary.lazy_load_shelves()
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, interface_type)
 		ui.open()
 
 /obj/machinery/computer/libraryconsole/ui_data(mob/user)
+	SSlibrary.lazy_load_shelves()
 	var/list/data = list()
 	data["can_db_request"] = can_db_request()
 	data["search_categories"] = SSlibrary.search_categories
@@ -82,6 +84,7 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 
 /obj/machinery/computer/libraryconsole/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
+	SSlibrary.lazy_load_shelves()
 	if(.)
 		return
 	switch(action)
@@ -409,6 +412,7 @@ GLOBAL_VAR_INIT(library_table_modified, 0)
 	return list(get_asset_datum(/datum/asset/spritesheet_batched/bibles))
 
 /obj/machinery/computer/libraryconsole/bookmanagement/proc/load_nearby_books()
+	SSlibrary.lazy_load_shelves()
 	for(var/datum/book_info/book as anything in SSlibrary.get_area_books(get_area(src)))
 		inventory[ref(book)] = book
 	inventory_update()


### PR DESCRIPTION
## Summary
- Load library shelves on-demand and hook into console/bookcase interactions

## Testing
- `bash tools/ci/check_misc.sh tgstation.dme`

------
https://chatgpt.com/codex/tasks/task_e_68a25352b2e48325b10446bcefbfb0c6