### PR TITLE
Limit stoplag backoff

### DIFF
--- a/code/__HELPERS/stoplag.dm
+++ b/code/__HELPERS/stoplag.dm
@@ -1,6 +1,8 @@
 //Key thing that stops lag. Cornerstone of performance in ss13, Just sitting here, in unsorted.dm. Now with dedicated file!
 
 ///Increases delay as the server gets more overloaded, as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
+///The delay increases exponentially but will not exceed `MAX_STOPLAG_TICKS` ticks to prevent excessively long sleeps.
+#define MAX_STOPLAG_TICKS 128
 #define DELTA_CALC max(((max(TICK_USAGE, world.cpu) / 100) * max(Master.sleep_delta-1,1)), 1)
 
 ///returns the number of ticks slept
@@ -17,12 +19,13 @@
 	return CEILING(DS2TICKS(initial_delay), 1)
 #else
 	. = 0
-	var/i = DS2TICKS(initial_delay)
-	do
-		. += CEILING(i * DELTA_CALC, 1)
-		sleep(i * world.tick_lag * DELTA_CALC)
-		i *= 2
-	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
+        var/i = DS2TICKS(initial_delay)
+        do
+                . += CEILING(i * DELTA_CALC, 1)
+                sleep(i * world.tick_lag * DELTA_CALC)
+                i = min(i * 2, MAX_STOPLAG_TICKS)
+        while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
 #endif
 
+#undef MAX_STOPLAG_TICKS
 #undef DELTA_CALC


### PR DESCRIPTION
## Summary
- cap stoplag's exponential backoff to 128 ticks

## Testing
- `tools/ci/check_filedirs.sh tgstation.dme`

------
https://chatgpt.com/codex/tasks/task_e_68a24aa7ec0c8325ac0db614aaa62abd