### PR TITLE
Enable entertainment jobs for players

### DIFF
--- a/code/modules/jobs/job_types/club_security.dm
+++ b/code/modules/jobs/job_types/club_security.dm
@@ -12,12 +12,14 @@
 	outfit = /datum/outfit/job/club_security
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV
-	display_order = JOB_DISPLAY_ORDER_CLUB_SECURITY
-	departments_list = list(
-		/datum/job_department/entertainment,
-	)
+       display_order = JOB_DISPLAY_ORDER_CLUB_SECURITY
+       department_for_prefs = /datum/job_department/entertainment
+       departments_list = list(
+               /datum/job_department/entertainment,
+       )
 
-	job_flags = STATION_JOB_FLAGS
+       job_flags = STATION_JOB_FLAGS
+       job_flags |= JOB_NEW_PLAYER_JOINABLE
 
 /datum/outfit/job/club_security
 	name = "Club Security"

--- a/code/modules/jobs/job_types/escort.dm
+++ b/code/modules/jobs/job_types/escort.dm
@@ -12,12 +12,14 @@
 	outfit = /datum/outfit/job/escort
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV
-	display_order = JOB_DISPLAY_ORDER_ESCORT
-	departments_list = list(
-		/datum/job_department/entertainment,
-	)
+       display_order = JOB_DISPLAY_ORDER_ESCORT
+       department_for_prefs = /datum/job_department/entertainment
+       departments_list = list(
+               /datum/job_department/entertainment,
+       )
 
-	job_flags = STATION_JOB_FLAGS
+       job_flags = STATION_JOB_FLAGS
+       job_flags |= JOB_NEW_PLAYER_JOINABLE
 
 /datum/outfit/job/escort
 	name = "Escort"

--- a/code/modules/jobs/job_types/souteneur.dm
+++ b/code/modules/jobs/job_types/souteneur.dm
@@ -12,12 +12,14 @@
 	outfit = /datum/outfit/job/souteneur
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV
-	display_order = JOB_DISPLAY_ORDER_SOUTENEUR
-	departments_list = list(
-/datum/job_department/entertainment,
-	)
+       display_order = JOB_DISPLAY_ORDER_SOUTENEUR
+       department_for_prefs = /datum/job_department/entertainment
+       departments_list = list(
+               /datum/job_department/entertainment,
+       )
 
-	job_flags = STATION_JOB_FLAGS
+       job_flags = STATION_JOB_FLAGS
+       job_flags |= JOB_NEW_PLAYER_JOINABLE
 
 /datum/outfit/job/souteneur
 	name = "Souteneur"

--- a/config/jobconfig.toml
+++ b/config/jobconfig.toml
@@ -134,6 +134,13 @@
 "Spawn Positions" = 1
 "Total Positions" = 1
 
+[CLUBSEC]
+"Playtime Requirements" = 0
+"Required Account Age" = 0
+"# Required Character Age" = 0
+"Spawn Positions" = 2
+"Total Positions" = 2
+
 [COOK]
 "Playtime Requirements" = 0
 "Required Account Age" = 0
@@ -185,6 +192,13 @@
 
 [ENGINEERING_GUARD]
 "Playtime Requirements" = 180
+"Required Account Age" = 0
+"# Required Character Age" = 0
+"Spawn Positions" = 2
+"Total Positions" = 2
+
+[ESCORT]
+"Playtime Requirements" = 0
 "Required Account Age" = 0
 "# Required Character Age" = 0
 "Spawn Positions" = 2
@@ -326,6 +340,13 @@
 "# Required Character Age" = 0
 "Spawn Positions" = 6
 "Total Positions" = 6
+
+[SOUTENEUR]
+"Playtime Requirements" = 0
+"Required Account Age" = 0
+"# Required Character Age" = 0
+"Spawn Positions" = 1
+"Total Positions" = 1
 
 [SHAFT_MINER]
 "Playtime Requirements" = 0


### PR DESCRIPTION
## Summary
- make Club Security, Escort and Souteneur selectable jobs
- add their job config entries

## Testing
- `bash tools/build/build.sh` *(fails: Executable not found in $PATH: "DreamMaker")*

------
https://chatgpt.com/codex/tasks/task_e_68a48ddacf108325ba8ffc3a25ce3bce